### PR TITLE
Add tooltips to each layer

### DIFF
--- a/src/data/layers/Advancements.tsx
+++ b/src/data/layers/Advancements.tsx
@@ -5,18 +5,20 @@
 
 import { createLayerTreeNode, createResetButton } from "data/common";
 import { main } from "data/projEntry";
-import MainDisplay from "features/resources/MainDisplay.vue";
 import { createCumulativeConversion } from "features/conversion";
-import { createReset } from "features/reset";
-import { createResource } from "features/resources/resource";
-import { createLayer } from "game/layers";
-import Decimal, { DecimalSource } from "lib/break_eternity";
-import { coerceComponent, render } from "util/vue";
 import { CoercableComponent, jsx, Visibility } from "features/feature";
 import { createMilestone } from "features/milestones/milestone";
-import { computed, ComputedRef } from "vue";
-import { formatWhole } from "util/break_eternity";
+import { createReset } from "features/reset";
+import MainDisplay from "features/resources/MainDisplay.vue";
+import { createResource } from "features/resources/resource";
+import { addTooltip } from "features/tooltips/tooltip";
+import { createResourceTooltip } from "features/trees/tree";
+import { createLayer } from "game/layers";
+import Decimal, { DecimalSource } from "lib/break_eternity";
 import { format } from "util/bignum";
+import { formatWhole } from "util/break_eternity";
+import { coerceComponent, render } from "util/vue";
+import { computed, ComputedRef } from "vue";
 import earth from "./Earth";
 
 const layer = createLayer("adv", () => {
@@ -74,6 +76,10 @@ const layer = createLayer("adv", () => {
         reset,
         glowColor: () => (Decimal.gt(conversion.actualGain.value, 0) ? "red" : "")
     }));
+    addTooltip(treeNode, {
+        display: createResourceTooltip(advancements),
+        pinnable: true
+    });
 
     const resetButton = createResetButton(() => ({
         conversion,

--- a/src/data/layers/Air.tsx
+++ b/src/data/layers/Air.tsx
@@ -2,20 +2,22 @@
  * @module
  * @hidden
  */
+import { main } from "data/projEntry";
 import { createCumulativeConversion } from "features/conversion";
 import { jsx, Visibility } from "features/feature";
 import { createReset } from "features/reset";
 import MainDisplay from "features/resources/MainDisplay.vue";
 import { createResource } from "features/resources/resource";
+import { addTooltip } from "features/tooltips/tooltip";
+import { createResourceTooltip } from "features/trees/tree";
+import { globalBus } from "game/events";
 import { createLayer } from "game/layers";
 import Decimal, { DecimalSource, format } from "util/bignum";
 import { render } from "util/vue";
+import { computed, unref } from "vue";
 import { createLayerTreeNode, createResetButton } from "../common";
 import advancements from "./Advancements";
-import { main } from "data/projEntry";
-import { computed, unref } from "vue";
 import life from "./Life";
-import { globalBus } from "game/events";
 
 const layer = createLayer("ai", () => {
     const id = "ai";
@@ -128,6 +130,11 @@ const layer = createLayer("ai", () => {
         color,
         reset
     }));
+    addTooltip(treeNode, {
+        display: createResourceTooltip(air),
+        pinnable: true,
+        style: () => (treeNode.visibility.value === Visibility.Visible ? "" : "display: none")
+    });
 
     const resetButton = createResetButton(() => ({
         conversion,

--- a/src/data/layers/Aqua.tsx
+++ b/src/data/layers/Aqua.tsx
@@ -22,6 +22,8 @@ import advancements from "./Advancements";
 import lightning from "./Lightning";
 import cryo from "./Cryo";
 import earth from "./Earth";
+import { addTooltip } from "features/tooltips/tooltip";
+import { createResourceTooltip } from "features/trees/tree";
 
 const layer = createLayer("a", () => {
     const id = "a";
@@ -170,6 +172,10 @@ const layer = createLayer("a", () => {
         color,
         reset
     }));
+    addTooltip(treeNode, {
+        display: createResourceTooltip(aqua),
+        pinnable: true
+    });
 
     const resetButton = createResetButton(() => ({
         conversion,

--- a/src/data/layers/Cryo.tsx
+++ b/src/data/layers/Cryo.tsx
@@ -19,6 +19,8 @@ import { computed, unref } from "vue";
 import flame from "./Flame";
 import life from "./Life";
 import aqua from "./Aqua";
+import { addTooltip } from "features/tooltips/tooltip";
+import { createResourceTooltip } from "features/trees/tree";
 
 const layer = createLayer("c", () => {
     const id = "c";
@@ -191,6 +193,11 @@ const layer = createLayer("c", () => {
         reset,
         glowColor: () => (challenges.some(c => c.canComplete.value) ? "red" : "")
     }));
+    addTooltip(treeNode, {
+        display: createResourceTooltip(cryo),
+        pinnable: true,
+        style: () => (treeNode.visibility.value === Visibility.Visible ? "" : "display: none")
+    });
 
     const resetButton = createResetButton(() => ({
         conversion,

--- a/src/data/layers/Earth.tsx
+++ b/src/data/layers/Earth.tsx
@@ -3,22 +3,23 @@
  * @hidden
  */
 import { createLayerTreeNode, createResetButton } from "data/common";
+import { createClickable } from "features/clickables/clickable";
 import { createCumulativeConversion, createPolynomialScaling } from "features/conversion";
+import { jsx, Visibility } from "features/feature";
+import { createGrid } from "features/grids/grid";
 import { createReset } from "features/reset";
 import MainDisplay from "features/resources/MainDisplay.vue";
 import { createResource, trackBest } from "features/resources/resource";
+import { addTooltip } from "features/tooltips/tooltip";
+import { createResourceTooltip } from "features/trees/tree";
 import { createLayer } from "game/layers";
 import Decimal, { DecimalSource } from "lib/break_eternity";
-import { main } from "../projEntry";
-import flame from "./Flame";
-import advancements from "./Advancements";
-import { jsx, Visibility } from "features/feature";
-import { render } from "util/vue";
-import { createGrid } from "features/grids/grid";
 import { format, formatWhole } from "util/break_eternity";
-import { computed, ref } from "vue";
-import { createClickable } from "features/clickables/clickable";
-import ModalVue from "components/Modal.vue";
+import { render } from "util/vue";
+import { computed } from "vue";
+import { main } from "../projEntry";
+import advancements from "./Advancements";
+import flame from "./Flame";
 
 const layer = createLayer("e", () => {
     const id = "e";
@@ -162,6 +163,11 @@ const layer = createLayer("e", () => {
         color,
         reset
     }));
+    addTooltip(treeNode, {
+        display: createResourceTooltip(earth),
+        pinnable: true,
+        style: () => (treeNode.visibility.value === Visibility.Visible ? "" : "display: none")
+    });
 
     const resetButton = createResetButton(() => ({
         conversion,

--- a/src/data/layers/Flame.tsx
+++ b/src/data/layers/Flame.tsx
@@ -22,6 +22,8 @@ import lightning from "./Lightning";
 import cryo from "./Cryo";
 import earth from "./Earth";
 import { globalBus } from "game/events";
+import { createResourceTooltip } from "features/trees/tree";
+import { addTooltip } from "features/tooltips/tooltip";
 
 const layer = createLayer("f", () => {
     const id = "f";
@@ -251,6 +253,10 @@ const layer = createLayer("f", () => {
                 ? "red"
                 : ""
     }));
+    addTooltip(treeNode, {
+        display: createResourceTooltip(flame),
+        pinnable: true
+    });
 
     const resetButton = createResetButton(() => ({
         conversion,

--- a/src/data/layers/Life.tsx
+++ b/src/data/layers/Life.tsx
@@ -24,6 +24,8 @@ import air from "./Air";
 import earth from "./Earth";
 import { globalBus } from "game/events";
 import { createClickable } from "features/clickables/clickable";
+import { addTooltip } from "features/tooltips/tooltip";
+import { createResourceTooltip } from "features/trees/tree";
 
 const layer = createLayer("l", () => {
     const id = "l";
@@ -277,6 +279,10 @@ const layer = createLayer("l", () => {
         reset,
         glowColor: () => (buyables.some(b => b.canPurchase.value) ? "red" : "")
     }));
+    addTooltip(treeNode, {
+        display: createResourceTooltip(life),
+        pinnable: true
+    });
 
     const resetButton = createResetButton(() => ({
         conversion,

--- a/src/data/layers/Lightning.tsx
+++ b/src/data/layers/Lightning.tsx
@@ -3,20 +3,22 @@
  * @hidden
  */
 import { main } from "data/projEntry";
+import { createClickable } from "features/clickables/clickable";
 import { createCumulativeConversion, createPolynomialScaling } from "features/conversion";
 import { jsx, Visibility } from "features/feature";
 import { createReset } from "features/reset";
 import MainDisplay from "features/resources/MainDisplay.vue";
 import { createResource, trackBest } from "features/resources/resource";
+import { addTooltip } from "features/tooltips/tooltip";
+import { createResourceTooltip } from "features/trees/tree";
 import { createLayer } from "game/layers";
-import { DecimalSource } from "util/bignum";
-import { render } from "util/vue";
-import { createLayerTreeNode, createResetButton } from "../common";
-import { createClickable } from "features/clickables/clickable";
-import { computed } from "vue";
-import advancements from "./Advancements";
 import Decimal from "lib/break_eternity";
+import { DecimalSource } from "util/bignum";
 import { format } from "util/break_eternity";
+import { render } from "util/vue";
+import { computed } from "vue";
+import { createLayerTreeNode, createResetButton } from "../common";
+import advancements from "./Advancements";
 
 const layer = createLayer("li", () => {
     const id = "li";
@@ -126,6 +128,11 @@ const layer = createLayer("li", () => {
         color,
         reset
     }));
+    addTooltip(treeNode, {
+        display: createResourceTooltip(lightning),
+        pinnable: true,
+        style: () => (treeNode.visibility.value === Visibility.Visible ? "" : "display: none")
+    });
 
     const resetButton = createResetButton(() => ({
         conversion,

--- a/src/features/tooltips/tooltip.ts
+++ b/src/features/tooltips/tooltip.ts
@@ -15,7 +15,7 @@ import {
     ProcessedComputable
 } from "util/computed";
 import { VueFeature } from "util/vue";
-import { Ref } from "vue";
+import { Ref, unref } from "vue";
 import { persistent } from "game/persistence";
 
 declare module "@vue/runtime-dom" {
@@ -105,7 +105,7 @@ export function addTooltip<T extends TooltipOptions>(
             },
             display,
             classes,
-            style,
+            style: unref(style),
             direction,
             xoffset,
             yoffset,


### PR DESCRIPTION
This includes 2 of the commits from 0.3.3 as well. That should be merged first, and the the only actual changes of this PR will be from this commit: [Add pinnable tooltips to all the layers](https://github.com/Jacorb90/Primordial-Tree/commit/c97c2a55c52d4171769faf6a6ed41a424b358009)